### PR TITLE
fix bug for commit failure

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,5 +23,9 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add -A .
-          git commit -m "generated"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "generated"
+            git push
+          fi


### PR DESCRIPTION
**概要**
GitHub Actionsのワークフローで、変更がないときにコミットが失敗する問題を解決します。

**詳細**
このActionは一日に2回トリガーするように設定されていますが、Github上で作業をしていない日は変更の差分が生じないため片方のActionがエラーで終了します。

![スクリーンショット (731)](https://github.com/shunki1006/shunki1006/assets/84959376/7831531c-3e9b-4543-8433-eb49133740ba)

この問題を修正するために、変更がないときにはcommitおよびpushを行わないように修正しました。

**その他**
この問題の根本の原因は一日に2回Actionをトリガーするようにしていることなので、もしそこまで頻繁に更新する必要がないのであれば、トリガーの頻度を落としても良いと思います。